### PR TITLE
Update to v2.4.4 and remove static library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sodre
+* @mbargull @sodre

--- a/README.md
+++ b/README.md
@@ -172,5 +172,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@mbargull](https://github.com/mbargull/)
 * [@sodre](https://github.com/sodre/)
 

--- a/recipe/0001-Dynamic-linking-for-Python-package.patch
+++ b/recipe/0001-Dynamic-linking-for-Python-package.patch
@@ -1,0 +1,11 @@
+--- src/python/setup.py
++++ src/python/setup.py
+@@ -41,7 +41,7 @@
+ 	ext_modules = [
+ 		Extension("seccomp", ["seccomp.pyx"],
+ 			# unable to handle libtool libraries directly
+-			extra_objects=["../.libs/libseccomp.a"],
++			libraries=["seccomp"],
+ 			# fix build warnings, see PEP 3123
+ 			extra_compile_args=["-fno-strict-aliasing"])
+ 	]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
-./autogen.sh
+autoreconf -fi
 ./configure \
-  --prefix=$PREFIX \
+  --prefix="${PREFIX}" \
+  --enable-static=no
 
 make

--- a/recipe/install_python.sh
+++ b/recipe/install_python.sh
@@ -1,12 +1,2 @@
-set -euf 
-
-pushd src/python
-
-sed -i "s|\.\./\.libs/libseccomp.a|$PREFIX/lib/libseccomp.a|" setup.py
-
-export VERSION_RELEASE=$PKG_VERSION
-export CPPFLAGS="-I$PREFIX/include $CPPFLAGS"
-
-$PYTHON -m pip install . --no-deps
-
-popd
+VERSION_RELEASE="${PKG_VERSION}" \
+  "${PYTHON}" -m pip install ./src/python --no-deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/seccomp/libseccomp/releases/download/v{{ version }}/libseccomp-{{ version }}.tar.gz
   sha256: 4e79738d1ef3c9b7ca9769f1f8b8d84fc17143c2c1c432e53b9c64787e0ff3eb
+  patches:
+    - 0001-Dynamic-linking-for-Python-package.patch
 
 build:
   number: 0
@@ -19,10 +21,6 @@ requirements:
     - autoconf
     - libtool
     - make
-
-test:
-  commands:
-    - test -l ${PREFIX}/libseccomp.so
 
 outputs:
   - name: libseccomp
@@ -39,24 +37,21 @@ outputs:
     test:
       commands:
         - test -f $PREFIX/lib/libseccomp.so
-        - test -f $PREFIX/lib/libseccomp.a
+        - test ! -f $PREFIX/lib/libseccomp.a
 
   - name: seccomp
     script: install_python.sh
     requirements:
       build:
         - {{ compiler('c') }}
-        - sed
-        - make
       host:
         - cython
         - python
         - pip
         - {{ pin_subpackage('libseccomp', exact=True) }}
       run:
+        - {{ pin_subpackage('libseccomp', exact=True) }}
         - python
-        # The python package statitically links to libseccomp
-        # so there is no need to add it here
     test:
       imports:
         - seccomp
@@ -78,4 +73,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - mbargull
     - sodre

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,15 @@
-{% set name = "seccomp-split" %}
-{% set version = "2.4.1" %}
+{% set version = "2.4.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: seccomp-split
   version: {{ version }}
 
 source:
-  url: https://github.com/seccomp/libseccomp/archive/v{{ version }}.tar.gz
-  sha256: 36aa502c0461ae9efc6c93ec2430d6badd9bf91ecbe73806baf7b7c6f687ab4f
+  url: https://github.com/seccomp/libseccomp/releases/download/v{{ version }}/libseccomp-{{ version }}.tar.gz
+  sha256: 4e79738d1ef3c9b7ca9769f1f8b8d84fc17143c2c1c432e53b9c64787e0ff3eb
 
 build:
-  number: 2
+  number: 0
   skip: True  # [not linux]
 
 requirements:
@@ -19,7 +18,7 @@ requirements:
     - automake
     - autoconf
     - libtool
-    - make  # [unix]
+    - make
 
 test:
   commands:
@@ -36,7 +35,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - make  # [unix]
+        - make
     test:
       commands:
         - test -f $PREFIX/lib/libseccomp.so
@@ -48,7 +47,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - sed
-        - make  # [unix]
+        - make
       host:
         - cython
         - python


### PR DESCRIPTION
closes gh-6
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Updates to `2.4.4` (closes https://github.com/conda-forge/seccomp-split-feedstock/pull/6) and removes the static library in accordance to https://github.com/conda-forge/cfep/blob/master/cfep-18.md#implementation.